### PR TITLE
item.quantity as int

### DIFF
--- a/paymenttype.go
+++ b/paymenttype.go
@@ -219,7 +219,7 @@ type (
 
 	// Item maps to item object
 	Item struct {
-		Quantity    string `json:"quantity"`
+		Quantity    int    `json:"quantity"`
 		Name        string `json:"name"`
 		Price       string `json:"price"`
 		Currency    string `json:"currency"`


### PR DESCRIPTION
I got a payment  
Item.Quantity  return as nuber not string
```
"items":[{"name":"300 gems","sku":"com.jingling.eng.gem30","price":"4.99","tax":"0.00","currency":"USD","quantity":1}]
```